### PR TITLE
chore: Remove deployment scripts that are specific to Young Innovations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - run: sudo apt-get install shellcheck
-      - run: shellcheck --exclude=SC2029 *.sh
       - run: npm install yarn
       - run: yarn
       - run: npx eslint .

--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,7 @@ $RECYCLE.BIN/
 config/deploy/parameters/*
 
 build/
+
+# Deployment scripts used by Young Innovations
+/script.sh
+/deploy.sh

--- a/README.md
+++ b/README.md
@@ -64,17 +64,3 @@ curl https://open-contracting.health/ver.txt
 ```
 
 or, open <https://open-contracting.health/ver.txt> in a browser.
-
-Deploy to staging (replace `BRANCH_NAME`):
-
-```bash
-./deploy.sh BRANCH_NAME covid19-dev
-```
-
-Deploy to production (replace `BRANCH_NAME`):
-
-```bash
-./deploy.sh BRANCH_NAME covid19
-```
-
-If no arguments are provided, by default, the `master` branch will be deployed to the staging server.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-ARG1=${1:-master}
-ARG2=${2:-covid19\-dev}
-ssh covid19-deployer@covid19admin.py.staging.yipl.com.np 'bash -s' < script.sh "$ARG1" "$ARG2"

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-ARG1=${1:-main}
-ARG2=${2:-covid19\-dev}
-echo "deploying covid19admin branch=$ARG1"
-cd /home/covid19-deployer/deploy || true
-./run.py "$ARG2" state.apply pillar='{"react_apps":{"covid19public":{"git":{"branch":'"$ARG1"'}}}}'
-exit


### PR DESCRIPTION
@KushalRaj @bigyan I am removing these scripts that are specific to Young Innovations and that don't interact with this repository. Feel free to use the scripts internally, but they do not belong in any OCP repository.

deploy.sh

```bash
#!/bin/bash
ARG1=${1:-master}
ARG2=${2:-covid19\-dev}
ssh covid19-deployer@covid19admin.py.staging.yipl.com.np 'bash -s' < script.sh "$ARG1" "$ARG2"
```

script.sh

```bash
#!/bin/bash
ARG1=${1:-main}
ARG2=${2:-covid19\-dev}
echo "deploying covid19admin branch=$ARG1"
cd /home/covid19-deployer/deploy || true
./run.py "$ARG2" state.apply pillar='{"react_apps":{"covid19public":{"git":{"branch":'"$ARG1"'}}}}'
exit
```

README.md

----

Deploy to staging (replace `BRANCH_NAME`):

```bash
./deploy.sh BRANCH_NAME covid19-dev
```

Deploy to production (replace `BRANCH_NAME`):

```bash
./deploy.sh BRANCH_NAME covid19
```

If no arguments are provided, by default, the `master` branch will be deployed to the staging server.
